### PR TITLE
Use new CMCONF system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # BringAuto Package Context Directory
 
-This Context directory is used for generating Packages for Fleet Protocol. It is a component of [BacPack system](https://github.com/bacpack-system). The build of Packages is done by [Packager] and the built Packages are stored in this [Package Repository](https://gitea.bringauto.com/fleet-protocol/package-repository).
+This Context directory is used for generating Packages for Fleet Protocol. It is a component of [BacPack system]. The build of Packages is done by [Packager] and the built Packages are stored in this [Package Repository].
 
 ## Compatibility
 
 - [Packager] v1.2.0 or newer
+
+## `config` Directory
+
+This directory is not specified by [Context Directory Specification]. It contains common configuration files for the build process.
 
 ## Helper Scripts
 
@@ -13,4 +17,8 @@ This Context directory is used for generating Packages for Fleet Protocol. It is
 - **`change_docker_name.sh`** - Changes the Docker image name in all package JSON files in the context directory. In the example, it changes `fleet-os-2` to `fleet-os-3`.
 
 
+
+[BacPack system]: https://github.com/bacpack-system
 [Packager]: https://github.com/bacpack-system/packager
+[Package Repository]: https://gitea.bringauto.com/fleet-protocol/package-repository
+[Context Directory Specification]: https://github.com/bacpack-system/packager/blob/master/doc/ContextStructure.md

--- a/config/CMCONF_FLEET_PROTOCOLConfig.cmake
+++ b/config/CMCONF_FLEET_PROTOCOLConfig.cmake
@@ -1,0 +1,44 @@
+
+# Example configuration for CMCONF system.
+#
+
+FIND_PACKAGE(CMLIB REQUIRED COMPONENTS CMCONF)
+
+CMCONF_INIT_SYSTEM(FLEET_PROTOCOL)
+
+#
+# Setting using upstream Package Repository by default for this system. This can be overridden by
+# App in CMakeLists.txt.
+#
+CMCONF_SET(BA_PACKAGE_LOCAL_USE OFF)
+CMCONF_SET(BA_PACKAGE_LOCAL_PATH "")
+
+#
+# The http authorization header is usually used for accessing private Package Repositories. This
+# example does not need it, but the variable must be set.
+#
+CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "")
+
+#
+# Setting BringAuto's Package Repository URI Template
+#
+CMCONF_SET(BA_PACKAGE_URI_REVISION master)
+CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-protocol/package-repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitea hosted public Package Repository:
+#
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.example.com/username/repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitea hosted private Package Repository.
+# Do not forget to specify Access Token
+#
+#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "token <token>")
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.example.com/username/repository/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitlab hosted private Package Repository.
+#
+#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "Bearer <token>")
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitlab.example.com/username/repository/-/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")

--- a/config/README.md
+++ b/config/README.md
@@ -1,11 +1,11 @@
 
 # FLEET_PROTOCOL System Configuration
 
-This directory contains configuration file for FLEET_PROTOCOL [CMCONF] system. It is used to set
+This directory contains the configuration file for FLEET_PROTOCOL [CMCONF] system. It is used to set
 required variables for [Package Tracker]. The most important variable is
-`FLEET_PROTOCOL_PACKAGE_REPOSITORY`, which sets uri of Package Repository used during builds.
+`BA_PACKAGE_URI_TEMPLATE_REMOTE`, which sets URI of Package Repository used during builds.
 
-This system must be installed to all Docker images. The [Packager]
+This system must be installed in all Docker images.
 
 More information about this system can be found in [Package Tracker Example].
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,16 @@
+
+# FLEET_PROTOCOL System Configuration
+
+This directory contains configuration file for FLEET_PROTOCOL [CMCONF] system. It is used to set
+required variables for [Package Tracker]. The most important variable is
+`FLEET_PROTOCOL_PACKAGE_REPOSITORY`, which sets uri of Package Repository used during builds.
+
+This system must be installed to all Docker images. The [Packager]
+
+More information about this system can be found in [Package Tracker Example].
+
+
+[Packager]: https://github.com/bacpack-system/packager
+[Package Tracker]: https://github.com/bacpack-system/package-tracker
+[Package Tracker Example]: https://github.com/bacpack-system/package-tracker/tree/master/example
+[CMCONF]: https://github.com/cmakelib/cmakelib-component-cmconf

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -34,6 +34,11 @@ RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc && \
     echo "export CXX=/usr/local/bin/g++" >> /root/.bashrc && \
     echo "export LD_LIBRARY_PATH=/usr/local/lib64" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/fedora40/Dockerfile
+++ b/docker/fedora40/Dockerfile
@@ -20,6 +20,11 @@ RUN dnf -y update && \
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/fedora41/Dockerfile
+++ b/docker/fedora41/Dockerfile
@@ -20,6 +20,11 @@ RUN dnf -y update && \
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/fedora42/Dockerfile
+++ b/docker/fedora42/Dockerfile
@@ -20,6 +20,11 @@ RUN dnf -y update && \
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/fleet-os-3/Dockerfile
+++ b/docker/fleet-os-3/Dockerfile
@@ -44,6 +44,11 @@ RUN chmod +x /root/init_toolchain.sh && \
 COPY os-release /etc/os-release
 COPY uname.txt /root/tools/
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN apt-get update && \
     apt-get purge -y \
       wget unzip && \

--- a/docker/ubuntu1804-aarch64/Dockerfile
+++ b/docker/ubuntu1804-aarch64/Dockerfile
@@ -18,6 +18,11 @@ RUN wget "https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/ubuntu2204/Dockerfile
+++ b/docker/ubuntu2204/Dockerfile
@@ -26,6 +26,11 @@ RUN apt-get update && \
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 

--- a/docker/ubuntu2404/Dockerfile
+++ b/docker/ubuntu2404/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get purge -y \
 RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
+# Install Fleet Protocol's CMCONF system
+COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+ENV CMLIB_DIR=/cmakelib
+RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd
 


### PR DESCRIPTION
Added installing new CMCONF system to images.

Requires [new version](https://github.com/bacpack-system/packager/pull/40) of Packager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet Protocol CMCONF preinstalled across Debian, Fedora, Ubuntu and Fleet OS images; CMCONF installed as a symlink and a CMLIB_DIR environment variable exposed for consistent builds.
  * Build images can reference remote package repositories with configurable URI templates and authentication options.

* **Documentation**
  * README updated to use reference-style links and clarified opening description.
  * Added config docs explaining the config directory and key CMCONF configuration for package tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->