### PR TITLE
Use os-release instead of lsb_release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # BringAuto Package Context Directory
 
-This Context directory is used for generating Packages for Fleet Protocol. It is a component of [BacPack system](https://github.com/bacpack-system). The build of Packages is done by [Packager](https://github.com/bacpack-system/packager) and the built Packages are stored in this [Package Repository](https://gitea.bringauto.com/fleet-protocol/package-repository).
+This Context directory is used for generating Packages for Fleet Protocol. It is a component of [BacPack system](https://github.com/bacpack-system). The build of Packages is done by [Packager] and the built Packages are stored in this [Package Repository](https://gitea.bringauto.com/fleet-protocol/package-repository).
+
+## Compatibility
+
+- [Packager] v1.2.0 or newer
 
 ## Helper Scripts
 
 - **`add_docker_to_matrix.sh`** - Adds a new Docker image to all package JSON files in the context directory. In the example, it adds the `ubuntu2310` Docker image to all package JSON files.
 
 - **`change_docker_name.sh`** - Changes the Docker image name in all package JSON files in the context directory. In the example, it changes `fleet-os-2` to `fleet-os-3`.
+
+
+[Packager]: https://github.com/bacpack-system/packager

--- a/docker/fleet-os-3/Dockerfile
+++ b/docker/fleet-os-3/Dockerfile
@@ -41,7 +41,7 @@ COPY init_toolchain.sh /root/
 COPY toolchain/oecore.sh /root/toolchain/oecore.sh
 RUN chmod +x /root/init_toolchain.sh && \
     /root/init_toolchain.sh /root/toolchain /root/tools
-COPY lsb_release.txt /root/tools/
+COPY os-release /etc/os-release
 COPY uname.txt /root/tools/
 
 RUN apt-get update && \

--- a/docker/fleet-os-3/init_toolchain.sh
+++ b/docker/fleet-os-3/init_toolchain.sh
@@ -84,7 +84,6 @@ function install_tools() {
   popd
   rm -r "${TMP_DIR}"
 
-  chmod +x "${TOOLS_INSTALL_DIR}/lsb_release"
   chmod +x "${TOOLS_INSTALL_DIR}/uname"
   echo 'PATH='"${TOOLS_INSTALL_DIR}"'/:$PATH' >> /root/.bashrc
 }

--- a/docker/fleet-os-3/init_toolchain.sh
+++ b/docker/fleet-os-3/init_toolchain.sh
@@ -25,7 +25,7 @@ fi
 
 
 
-TOOLS_PACKAGE_URI="https://github.com/bacpack-system/packager/releases/download/v1.0.0/bringauto-packager-tools_v1.0.0_x86-64-linux.zip"
+TOOLS_PACKAGE_URI="https://github.com/bacpack-system/packager-tools/releases/download/v1.0.0/bringauto-packager-tools_v1.0.0_x86-64-linux.zip"
 
 #
 # Install our BringAuto Fleet

--- a/docker/fleet-os-3/lsb_release.txt
+++ b/docker/fleet-os-3/lsb_release.txt
@@ -1,2 +1,0 @@
-Distributor ID:	fleet-os
-Release:	3

--- a/docker/fleet-os-3/os-release
+++ b/docker/fleet-os-3/os-release
@@ -1,0 +1,2 @@
+ID=fleet-os
+VERSION_ID="3"

--- a/docker/fleet-os-3/os-release
+++ b/docker/fleet-os-3/os-release
@@ -1,2 +1,4 @@
 ID=fleet-os
 VERSION_ID="3"
+NAME="Fleet OS"
+PRETTY_NAME="Fleet OS 3"

--- a/docker/ubuntu1804-aarch64/Dockerfile
+++ b/docker/ubuntu1804-aarch64/Dockerfile
@@ -32,7 +32,6 @@ RUN mkdir /root/.ssh && \
 COPY init_toolchain.sh /root/
 RUN chmod +x /root/init_toolchain.sh && \
     /root/init_toolchain.sh /root/tools
-COPY lsb_release.txt /root/tools/
 COPY uname.txt /root/tools/
 
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-o", "ListenAddress=0.0.0.0"]

--- a/docker/ubuntu1804-aarch64/init_toolchain.sh
+++ b/docker/ubuntu1804-aarch64/init_toolchain.sh
@@ -32,7 +32,6 @@ function install_tools() {
   popd
   rm -r "${TMP_DIR}"
 
-  chmod +x "${TOOLS_INSTALL_DIR}/lsb_release"
   chmod +x "${TOOLS_INSTALL_DIR}/uname"
   TMP_PATH=$PATH
   echo 'PATH='"${TOOLS_INSTALL_DIR}"'/:'"${TMP_PATH}"'' >> /root/.ssh/environment

--- a/docker/ubuntu1804-aarch64/init_toolchain.sh
+++ b/docker/ubuntu1804-aarch64/init_toolchain.sh
@@ -5,7 +5,7 @@ set -e
 TOOLS_INSTALL_DIR="$1"
 TMP_DIR="/tmp/toolchain-install"
 
-TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v0.3.2/bringauto-packager-tools_v0.3.2_x86-64-linux.zip"
+TOOLS_PACKAGE_URI="https://github.com/bacpack-system/packager-tools/releases/download/v1.0.0/bringauto-packager-tools_v1.0.0_x86-64-linux.zip"
 
 if [[ ${TOOLS_INSTALL_DIR} = "" ]]
 then

--- a/docker/ubuntu1804-aarch64/lsb_release.txt
+++ b/docker/ubuntu1804-aarch64/lsb_release.txt
@@ -1,2 +1,0 @@
-Distributor ID:	Ubuntu
-Release:	18.04


### PR DESCRIPTION
Upcoming Packager uses os-release instead of lsb_release. These changes reflects this new behaviour.

Updated `fleet-os-3` and `ubuntu1804-aarch64` images.

- [ ] After merge of [Packager PR](https://github.com/bacpack-system/packager/pull/35), update link to tools here!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized OS metadata by adopting the /etc/os-release format (ID, VERSION_ID, NAME, PRETTY_NAME) for images to improve compatibility.
- Chores
  - Removed legacy LSB metadata from image assets.
  - Updated toolchain packaging source and simplified initialization by removing legacy executable permission handling.
- Documentation
  - Added a Compatibility section noting Packager v1.2.0 or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->