### PR TITLE
Update cxxopts to v3.1.1

### DIFF
--- a/package/cxxopts/cxxopts_v3_debug.json
+++ b/package/cxxopts/cxxopts_v3_debug.json
@@ -3,7 +3,7 @@
   "DependsOn": [],
   "Git": {
     "URI": "https://github.com/jarro2783/cxxopts.git",
-    "Revision": "v3.1.0"
+    "Revision": "v3.1.1"
   },
   "Build": {
     "CMake": {
@@ -16,7 +16,7 @@
   },
   "Package": {
     "Name": "cxxopts",
-    "VersionTag": "v3.1.0",
+    "VersionTag": "v3.1.1",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/package/cxxopts/cxxopts_v3_release.json
+++ b/package/cxxopts/cxxopts_v3_release.json
@@ -3,7 +3,7 @@
   "DependsOn": [],
   "Git": {
     "URI": "https://github.com/jarro2783/cxxopts.git",
-    "Revision": "v3.1.0"
+    "Revision": "v3.1.1"
   },
   "Build": {
     "CMake": {
@@ -16,7 +16,7 @@
   },
   "Package": {
     "Name": "cxxopts",
-    "VersionTag": "v3.1.0",
+    "VersionTag": "v3.1.1",
     "PlatformString": {
       "Mode": "auto"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated cxxopts dependency metadata to v3.1.1 (from v3.1.0) for both debug and release builds.
  * Aligned version tags and Git revision references across configurations.
  * Change is limited to packaging metadata; no functional or UI changes.
  * No other files or settings modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->