### PR TITLE
Add support for Aeron 1.48.6

### DIFF
--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -25,7 +25,7 @@ RUN cd /gcc/objdir && \
     make -j$(nproc) && \
     make install
 
-RUN wget "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.sh" -O cmake.sh && \
+RUN wget "https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
     rm ./cmake.sh

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -8,6 +8,13 @@ RUN apt-get update && \
     binutils build-essential flex git libssl-dev lsb-release make openssh-server patchelf software-properties-common wget && \
     rm -rf /var/lib/apt/lists/*
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN git clone --depth=1 --single-branch --branch=releases/gcc-13.2.0 https://gcc.gnu.org/git/gcc.git /gcc && \
     cd /gcc && \
     contrib/download_prerequisites && \

--- a/docker/fedora40/Dockerfile
+++ b/docker/fedora40/Dockerfile
@@ -8,6 +8,12 @@ RUN dnf -y update && \
     automake binutils gcc gcc-c++ git kernel-devel lsb-release make openssh-server openssl-devel patchelf wget \
     && dnf clean all
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN dnf -y update && \
+    dnf -y install java-latest-openjdk java-latest-openjdk-devel \
+    && dnf clean all
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \

--- a/docker/fedora41/Dockerfile
+++ b/docker/fedora41/Dockerfile
@@ -8,6 +8,12 @@ RUN dnf -y update && \
     automake binutils gcc gcc-c++ git kernel-devel lsb-release make openssh-server openssl-devel patchelf wget \
     && dnf clean all
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN dnf -y update && \
+    dnf -y install java-latest-openjdk java-latest-openjdk-devel \
+    && dnf clean all
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \

--- a/docker/fedora42/Dockerfile
+++ b/docker/fedora42/Dockerfile
@@ -8,6 +8,12 @@ RUN dnf -y update && \
     automake binutils gcc gcc-c++ git kernel-devel lsb-release make openssh-server openssl-devel patchelf wget \
     && dnf clean all
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN dnf -y update && \
+    dnf -y install java-latest-openjdk java-latest-openjdk-devel \
+    && dnf clean all
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \

--- a/docker/fleet-os-3/Dockerfile
+++ b/docker/fleet-os-3/Dockerfile
@@ -30,7 +30,7 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # Do we need it? It should be part of the toolchain
-RUN wget "https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0-linux-x86_64.sh" -O cmake.sh && \
+RUN wget "https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
     rm ./cmake.sh

--- a/docker/fleet-os-3/Dockerfile
+++ b/docker/fleet-os-3/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update && \
       findutils && \
     rm -rf /var/lib/apt/lists/*
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
 # Generate the locale for en_US.UTF-8
 RUN locale-gen en_US.UTF-8
 

--- a/docker/ubuntu2204/Dockerfile
+++ b/docker/ubuntu2204/Dockerfile
@@ -13,6 +13,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \

--- a/docker/ubuntu2204/Dockerfile
+++ b/docker/ubuntu2204/Dockerfile
@@ -17,10 +17,10 @@ RUN apt-get update && \
 # For example: Processing Aeron mapping files
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        default-jdk && \
+        openjdk-17-jdk && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget "https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0-linux-x86_64.sh" -O cmake.sh && \
+RUN wget "https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
     rm ./cmake.sh

--- a/docker/ubuntu2404/Dockerfile
+++ b/docker/ubuntu2404/Dockerfile
@@ -8,6 +8,13 @@ RUN apt-get update && \
       	coreutils lsb-release build-essential  openssh-server git libssl-dev wget patchelf && \
     rm -rf /var/lib/apt/lists/*
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \

--- a/docker/ubuntu2504/Dockerfile
+++ b/docker/ubuntu2504/Dockerfile
@@ -8,6 +8,13 @@ RUN apt-get update && \
       	coreutils lsb-release build-essential  openssh-server git libssl-dev wget patchelf && \
     rm -rf /var/lib/apt/lists/*
 
+# Java is needed for build of some tools.
+# For example: Processing Aeron mapping files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh" -O cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
@@ -21,9 +28,9 @@ RUN git clone https://github.com/cmakelib/cmakelib.git /cmakelib
 RUN echo "export CMLIB_DIR=/cmakelib" >> /root/.bashrc
 
 # Install Fleet Protocol's CMCONF system
-COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
-ENV CMLIB_DIR=/cmakelib
-RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
+#COPY --from=package-context config/CMCONF_FLEET_PROTOCOLConfig.cmake /etc
+#ENV CMLIB_DIR=/cmakelib
+#RUN cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P /etc/CMCONF_FLEET_PROTOCOLConfig.cmake
 
 RUN sed -ri 's/#?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN mkdir -p /run/sshd

--- a/package/aeron/aeron_debug.json
+++ b/package/aeron/aeron_debug.json
@@ -1,0 +1,41 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/aeron-io/aeron.git",
+    "Revision": "1.48.6"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "STANDALONE_BUILD": "ON",
+        "AERON_BUILD_SAMPLES": "OFF",
+        "AERON_TESTS": "OFF",
+        "AERON_SYSTEM_TESTS": "OFF",
+        "AERON_UNIT_TESTS": "OFF",
+        "BUILD_AERON_DRIVER": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "aeron",
+    "VersionTag": "v1.48.6",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2204",
+      "fleet-os-3",
+      "debian12",
+      "ubuntu2404",
+      "ubuntu2504",
+      "fedora41",
+      "fedora42"
+    ]
+  }
+}

--- a/package/aeron/aeron_release.json
+++ b/package/aeron/aeron_release.json
@@ -1,0 +1,41 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/aeron-io/aeron.git",
+    "Revision": "1.48.6"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "STANDALONE_BUILD": "ON",
+        "AERON_BUILD_SAMPLES": "OFF",
+        "AERON_TESTS": "OFF",
+        "AERON_SYSTEM_TESTS": "OFF",
+        "AERON_UNIT_TESTS": "OFF",
+        "BUILD_AERON_DRIVER": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "aeron",
+    "VersionTag": "v1.48.6",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2204",
+      "fleet-os-3",
+      "debian12",
+      "ubuntu2404",
+      "ubuntu2504",
+      "fedora41",
+      "fedora42"
+    ]
+  }
+}

--- a/package/async-function-execution/async-function-execution_debug.json
+++ b/package/async-function-execution/async-function-execution_debug.json
@@ -1,0 +1,44 @@
+{
+  "Env": {},
+  "DependsOn": [
+	"aeron",
+	"nlohmann-json"
+  ],
+  "Git": {
+    "URI": "https://github.com/bringauto/async-function-execution.git",
+    "Revision": "v0.1.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BRINGAUTO_INSTALL": "ON",
+        "BRINGAUTO_PACKAGE": "ON",
+        "BRINGAUTO_SYSTEM_DEP": "ON",
+        "BRINGAUTO_SAMPLES": "OFF",
+        "BRINGAUTO_TESTS": "OFF"
+      }
+    }
+  },
+  "Package": {
+    "Name": "async-function-execution",
+    "VersionTag": "v0.1.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2204",
+      "fleet-os-3",
+      "debian12",
+      "ubuntu2404",
+      "ubuntu2504",
+      "fedora41",
+      "fedora42"
+    ]
+  }
+}

--- a/package/async-function-execution/async-function-execution_debug.json
+++ b/package/async-function-execution/async-function-execution_debug.json
@@ -1,8 +1,8 @@
 {
   "Env": {},
   "DependsOn": [
-	"aeron",
-	"nlohmann-json"
+    "aeron",
+    "nlohmann-json"
   ],
   "Git": {
     "URI": "https://github.com/bringauto/async-function-execution.git",

--- a/package/async-function-execution/async-function-execution_release.json
+++ b/package/async-function-execution/async-function-execution_release.json
@@ -1,0 +1,44 @@
+{
+  "Env": {},
+  "DependsOn": [
+	"aeron",
+	"nlohmann-json"
+  ],
+  "Git": {
+    "URI": "https://github.com/bringauto/async-function-execution.git",
+    "Revision": "v0.1.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BRINGAUTO_INSTALL": "ON",
+        "BRINGAUTO_PACKAGE": "ON",
+        "BRINGAUTO_SYSTEM_DEP": "ON",
+        "BRINGAUTO_SAMPLES": "OFF",
+        "BRINGAUTO_TESTS": "OFF"
+      }
+    }
+  },
+  "Package": {
+    "Name": "async-function-execution",
+    "VersionTag": "v0.1.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2204",
+      "fleet-os-3",
+      "debian12",
+      "ubuntu2404",
+      "ubuntu2504",
+      "fedora41",
+      "fedora42"
+    ]
+  }
+}

--- a/package/async-function-execution/async-function-execution_release.json
+++ b/package/async-function-execution/async-function-execution_release.json
@@ -1,8 +1,8 @@
 {
   "Env": {},
   "DependsOn": [
-	"aeron",
-	"nlohmann-json"
+    "aeron",
+    "nlohmann-json"
   ],
   "Git": {
     "URI": "https://github.com/bringauto/async-function-execution.git",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Aeron v1.48.6 debug and release manifests with expanded Docker image coverage.
  - Added async-function-execution v0.1.0 debug and release manifests for multi-OS builds.
- Chores
  - Installed Java JDK across multiple base images to support build tooling.
  - Upgraded CMake installer version across images.
  - Image cleanup and hygiene improvements.
  - Ubuntu 25.04: removed installer artifact and disabled obsolete config steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->