### PR TITLE
Migrate to package-tracker v2

### DIFF
--- a/config/CMCONF_FLEET_PROTOCOLConfig.cmake
+++ b/config/CMCONF_FLEET_PROTOCOLConfig.cmake
@@ -1,4 +1,3 @@
-
 # Example configuration for CMCONF system.
 #
 
@@ -14,10 +13,12 @@ CMCONF_SET(BA_PACKAGE_LOCAL_USE OFF)
 CMCONF_SET(BA_PACKAGE_LOCAL_PATH "")
 
 #
-# The http authorization header is usually used for accessing private Package Repositories. This
+# The http header is usually used for accessing private Package Repositories. This
 # example does not need it, but the variable must be set.
 #
-CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "")
+CMCONF_SET(BA_PACKAGE_GIT_ARCHIVE_PATH_TEMPLATE "")
+CMCONF_SET(BA_PACKAGE_HTTP_HEADER "")
+CMCONF_SET(BA_PACKAGE_TEMPLATE_ARGS_URI_ESCAPE OFF)
 
 #
 # Setting BringAuto's Package Repository URI Template
@@ -34,11 +35,11 @@ CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-pro
 # Gitea hosted private Package Repository.
 # Do not forget to specify Access Token
 #
-#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "token <token>")
+#CMCONF_SET(BA_PACKAGE_HTTP_HEADER "Authorization: token <token>")
 #CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.example.com/username/repository/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
 
 #
 # Gitlab hosted private Package Repository.
 #
-#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "Bearer <token>")
+#CMCONF_SET(BA_PACKAGE_HTTP_HEADER "Authorization: Bearer <token>")
 #CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitlab.example.com/username/repository/-/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")


### PR DESCRIPTION
## Summary

- Rename `BA_PACKAGE_HTTP_AUTHORIZATION_HEADER` to `BA_PACKAGE_HTTP_HEADER`
- Add new required variables `BA_PACKAGE_GIT_ARCHIVE_PATH_TEMPLATE` and `BA_PACKAGE_TEMPLATE_ARGS_URI_ESCAPE`
- Update commented-out examples to prepend `Authorization: ` to header values

Follows the [package-tracker v1→v2 migration guide](https://github.com/bacpack-system/package-tracker/blob/master/doc/MigrationGuide_1_to_2.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced HTTP header configuration options for private package repositories, providing improved authentication header management with separate configuration variables for flexible setup.

* **Configuration Updates**
  * Updated configuration templates with new parameters for customized header and URI template handling in package repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->