### PR TITLE
bump fleet-protocol-interface to v2.1.0

### DIFF
--- a/package/fleet-protocol-interface/fleet_protocol_debug.json
+++ b/package/fleet-protocol-interface/fleet_protocol_debug.json
@@ -3,7 +3,7 @@
   "DependsOn": [],
   "Git": {
     "URI": "https://github.com/bringauto/fleet-protocol.git",
-    "Revision": "v2.0.0"
+    "Revision": "v2.1.0"
   },
   "Build": {
     "CMake": {
@@ -18,7 +18,7 @@
   },
   "Package": {
     "Name": "fleet-protocol-interface",
-    "VersionTag": "v2.0.0",
+    "VersionTag": "v2.1.0",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/package/fleet-protocol-interface/fleet_protocol_release.json
+++ b/package/fleet-protocol-interface/fleet_protocol_release.json
@@ -3,7 +3,7 @@
   "DependsOn": [],
   "Git": {
     "URI": "https://github.com/bringauto/fleet-protocol.git",
-    "Revision": "v2.0.0"
+    "Revision": "v2.1.0"
   },
   "Build": {
     "CMake": {
@@ -18,7 +18,7 @@
   },
   "Package": {
     "Name": "fleet-protocol-interface",
-    "VersionTag": "v2.0.0",
+    "VersionTag": "v2.1.0",
     "PlatformString": {
       "Mode": "auto"
     },


### PR DESCRIPTION
Adds the optional forward_command_on_receive entry point to the module gateway interface (released in fleet-protocol v2.1.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Fleet Protocol Interface package version to v2.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->