### PR TITLE
add teleop-module app definition (v1.0.4)

### DIFF
--- a/app/teleop-module/teleop-module_debug.json
+++ b/app/teleop-module/teleop-module_debug.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://gitlab.bringauto.com/bring-auto/teleoperation/control/teleop-module.git",
+    "Revision": "v1.0.4"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BRINGAUTO_INSTALL": "ON",
+        "FLEET_PROTOCOL_BUILD_MODULE_GATEWAY": "ON",
+        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "teleop-module",
+    "VersionTag": "v1.0.4",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-3",
+      "ubuntu2404",
+      "fedora44",
+      "debian12"
+    ]
+  }
+}

--- a/app/teleop-module/teleop-module_release.json
+++ b/app/teleop-module/teleop-module_release.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://gitlab.bringauto.com/bring-auto/teleoperation/control/teleop-module.git",
+    "Revision": "v1.0.4"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BRINGAUTO_INSTALL": "ON",
+        "FLEET_PROTOCOL_BUILD_MODULE_GATEWAY": "ON",
+        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "teleop-module",
+    "VersionTag": "v1.0.4",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-3",
+      "ubuntu2404",
+      "fedora44",
+      "debian12"
+    ]
+  }
+}


### PR DESCRIPTION
Adds `teleop-module` as an app in the fleet-protocol context (modeled on transparent-module). Requested as part of the fpi v2.1.0 downstream work; teleop-module v1.0.4 already targets fleet-protocol-interface v2.1.0.

### Decisions made (please review)
- **Git URI**: `https://gitlab.bringauto.com/bring-auto/teleoperation/control/teleop-module.git` — teleop-module lives on **GitLab**, unlike every other context entry (github.com). ⚠️ The build environment/container must have access to this private GitLab repo (token/SSH); the public-github assumption doesn't hold here.
- **Revision/VersionTag**: `v1.0.4` (latest tag).
- **Build defines**: `BRINGAUTO_INSTALL=ON` + `FLEET_PROTOCOL_BUILD_MODULE_GATEWAY=ON` + `FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER=ON`. teleop-module defaults `MODULE_GATEWAY` **OFF** (unlike transparent-module), so it's enabled explicitly to produce the module-gateway shared lib. external-server is left ON (default) — this pulls heavy deps (cpprestsdk, boost, fleet-http-client-shared); set OFF if only the module-gateway side is wanted here.
- **DockerMatrix**: fleet-os-3, ubuntu24.04, fedora44, debian12 (the agreed target platforms). Adjust if teleop deploys elsewhere.

Definition only — not yet built. JSON validated and structurally matches the existing app defs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added debug and release build configurations for teleop-module v1.0.4, supporting multiple platform targets and Docker image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->