### PR TITLE
bump downstreams to fpi v2.1.0 tags

### DIFF
--- a/app/io-module/io-module_debug.json
+++ b/app/io-module/io-module_debug.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/io-module.git",
-    "Revision": "v1.3.4"
+    "Revision": "v1.3.6"
   },
   "Build": {
     "CMake": {
@@ -14,7 +14,7 @@
   },
   "Package": {
     "Name": "io-module",
-    "VersionTag": "v1.3.4",
+    "VersionTag": "v1.3.6",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/io-module/io-module_release.json
+++ b/app/io-module/io-module_release.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/io-module.git",
-    "Revision": "v1.3.4"
+    "Revision": "v1.3.6"
   },
   "Build": {
     "CMake": {
@@ -14,7 +14,7 @@
   },
   "Package": {
     "Name": "io-module",
-    "VersionTag": "v1.3.4",
+    "VersionTag": "v1.3.6",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/mission-module/mission-module_debug.json
+++ b/app/mission-module/mission-module_debug.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/mission-module.git",
-    "Revision": "v1.3.2"
+    "Revision": "v2.0.1"
   },
   "Build": {
     "CMake": {
@@ -17,7 +17,7 @@
   },
   "Package": {
     "Name": "mission-module",
-    "VersionTag": "v1.3.2",
+    "VersionTag": "v2.0.1",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/mission-module/mission-module_release.json
+++ b/app/mission-module/mission-module_release.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/mission-module.git",
-    "Revision": "v1.3.2"
+    "Revision": "v2.0.1"
   },
   "Build": {
     "CMake": {
@@ -17,7 +17,7 @@
   },
   "Package": {
     "Name": "mission-module",
-    "VersionTag": "v1.3.2",
+    "VersionTag": "v2.0.1",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/transparent-module/transparent-module_debug.json
+++ b/app/transparent-module/transparent-module_debug.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/transparent-module.git",
-    "Revision": "v1.0.3"
+    "Revision": "v1.0.6"
   },
   "Build": {
     "CMake": {
@@ -14,7 +14,7 @@
   },
   "Package": {
     "Name": "transparent-module",
-    "VersionTag": "v1.0.3",
+    "VersionTag": "v1.0.6",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/transparent-module/transparent-module_release.json
+++ b/app/transparent-module/transparent-module_release.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/transparent-module.git",
-    "Revision": "v1.0.3"
+    "Revision": "v1.0.6"
   },
   "Build": {
     "CMake": {
@@ -14,7 +14,7 @@
   },
   "Package": {
     "Name": "transparent-module",
-    "VersionTag": "v1.0.3",
+    "VersionTag": "v1.0.6",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/package/fleet-protocol-internal-client/internal_client_debug.json
+++ b/package/fleet-protocol-internal-client/internal_client_debug.json
@@ -7,7 +7,7 @@
   ],
   "Git": {
     "URI": "https://github.com/bringauto/internal-client-cpp.git",
-    "Revision": "v1.1.4"
+    "Revision": "v1.1.5"
   },
   "Build": {
     "CMake": {
@@ -21,7 +21,7 @@
   },
   "Package": {
     "Name": "fleet-protocol-internal-client",
-    "VersionTag": "v1.1.4",
+    "VersionTag": "v1.1.5",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/package/fleet-protocol-internal-client/internal_client_release.json
+++ b/package/fleet-protocol-internal-client/internal_client_release.json
@@ -7,7 +7,7 @@
   ],
   "Git": {
     "URI": "https://github.com/bringauto/internal-client-cpp.git",
-    "Revision": "v1.1.4"
+    "Revision": "v1.1.5"
   },
   "Build": {
     "CMake": {
@@ -21,7 +21,7 @@
   },
   "Package": {
     "Name": "fleet-protocol-internal-client",
-    "VersionTag": "v1.1.4",
+    "VersionTag": "v1.1.5",
     "PlatformString": {
       "Mode": "auto"
     },


### PR DESCRIPTION
Points the context at module/package versions that build against fleet-protocol-interface v2.1.0, replacing the older tags that pin fpi v2.0.0 / stale deps:

| entry | old | new |
|---|---|---|
| io-module | v1.3.4 | **v1.3.6** |
| mission-module | v1.3.2 | **v2.0.1** |
| transparent-module | v1.0.3 | **v1.0.6** |
| fleet-protocol-internal-client | v1.1.4 | **v1.1.5** (new release, deps aligned) |

All four target versions have fpi v2.1.0 + nlohmann-json v3.12.0 confirmed in their Dependencies.cmake.

**module-gateway is intentionally not bumped here** — its master is diverged from v1.4.1 (18 commits behind), so a clean tag needs a decision on the right source branch.

Not yet build-verified end-to-end; recommend re-running the app/package builds before merge.