### PR TITLE
bump module-gateway to v1.4.2

### DIFF
--- a/app/module-gateway/module-gateway_debug.json
+++ b/app/module-gateway/module-gateway_debug.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/module-gateway.git",
-    "Revision": "v1.4.1"
+    "Revision": "v1.4.2"
   },
   "Build": {
     "CMake": {
@@ -18,7 +18,7 @@
   },
   "Package": {
     "Name": "module-gateway",
-    "VersionTag": "v1.4.1",
+    "VersionTag": "v1.4.2",
     "PlatformString": {
       "Mode": "auto"
     },

--- a/app/module-gateway/module-gateway_release.json
+++ b/app/module-gateway/module-gateway_release.json
@@ -2,7 +2,7 @@
   "Env": {},
   "Git": {
     "URI": "https://github.com/bringauto/module-gateway.git",
-    "Revision": "v1.4.1"
+    "Revision": "v1.4.2"
   },
   "Build": {
     "CMake": {
@@ -17,7 +17,7 @@
   },
   "Package": {
     "Name": "module-gateway",
-    "VersionTag": "v1.4.1",
+    "VersionTag": "v1.4.2",
     "PlatformString": {
       "Mode": "auto"
     },


### PR DESCRIPTION
Points the context at module-gateway **v1.4.2** (just tagged from master), replacing v1.4.1 which pinned fpi v2.0.0 / old deps.

v1.4.2 = master + version bump; master is a functional superset of v1.4.1 (all QUIC/BAF-1256 features + fixes present, 43 commits ahead) and pins fleet-protocol-interface v2.1.0. Completes the downstream set alongside #26 (io-module v1.3.6, mission-module v2.0.1, transparent-module v1.0.6, internal-client v1.1.5).