### PR TITLE
teleop-module: v1.0.5 gateway-only (BRINGAUTO_PACKAGE=ON, external-server OFF)

### DIFF
--- a/app/teleop-module/teleop-module_debug.json
+++ b/app/teleop-module/teleop-module_debug.json
@@ -2,21 +2,23 @@
   "Env": {},
   "Git": {
     "URI": "https://gitlab.bringauto.com/bring-auto/teleoperation/control/teleop-module.git",
-    "Revision": "v1.0.4"
+    "Revision": "v1.0.5"
   },
   "Build": {
     "CMake": {
       "Defines": {
         "CMAKE_BUILD_TYPE": "Debug",
         "BRINGAUTO_INSTALL": "ON",
+        "BRINGAUTO_PACKAGE": "ON",
+        "BRINGAUTO_SYSTEM_DEP": "OFF",
         "FLEET_PROTOCOL_BUILD_MODULE_GATEWAY": "ON",
-        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "ON"
+        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "OFF"
       }
     }
   },
   "Package": {
     "Name": "teleop-module",
-    "VersionTag": "v1.0.4",
+    "VersionTag": "v1.0.5",
     "PlatformString": {
       "Mode": "auto"
     },
@@ -26,10 +28,7 @@
   },
   "DockerMatrix": {
     "ImageNames": [
-      "fleet-os-3",
-      "ubuntu2404",
-      "fedora44",
-      "debian12"
+      "fleet-os-3"
     ]
   }
 }

--- a/app/teleop-module/teleop-module_release.json
+++ b/app/teleop-module/teleop-module_release.json
@@ -2,21 +2,23 @@
   "Env": {},
   "Git": {
     "URI": "https://gitlab.bringauto.com/bring-auto/teleoperation/control/teleop-module.git",
-    "Revision": "v1.0.4"
+    "Revision": "v1.0.5"
   },
   "Build": {
     "CMake": {
       "Defines": {
         "CMAKE_BUILD_TYPE": "Release",
         "BRINGAUTO_INSTALL": "ON",
+        "BRINGAUTO_PACKAGE": "ON",
+        "BRINGAUTO_SYSTEM_DEP": "OFF",
         "FLEET_PROTOCOL_BUILD_MODULE_GATEWAY": "ON",
-        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "ON"
+        "FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER": "OFF"
       }
     }
   },
   "Package": {
     "Name": "teleop-module",
-    "VersionTag": "v1.0.4",
+    "VersionTag": "v1.0.5",
     "PlatformString": {
       "Mode": "auto"
     },
@@ -26,10 +28,7 @@
   },
   "DockerMatrix": {
     "ImageNames": [
-      "fleet-os-3",
-      "ubuntu2404",
-      "fedora44",
-      "debian12"
+      "fleet-os-3"
     ]
   }
 }


### PR DESCRIPTION
Updates the teleop-module context def to v1.0.5, gateway-only:
- Revision/VersionTag v1.0.4 → **v1.0.5** (v1.0.5 carries the CMakeLists fix that respects an explicit external-server OFF under BRINGAUTO_PACKAGE)
- Defines: BRINGAUTO_PACKAGE=ON, BRINGAUTO_SYSTEM_DEP=OFF, FLEET_PROTOCOL_BUILD_MODULE_GATEWAY=ON, FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER=OFF (was external-server ON)
- DockerMatrix: fleet-os-3

Produces the gateway-only plugin (libteleop-module-gateway-shared.so, no external-server .so). Verified building on fleet-os-3. Supersedes #28.